### PR TITLE
Add support for class expressions.

### DIFF
--- a/src/noUninitializedRule.ts
+++ b/src/noUninitializedRule.ts
@@ -39,7 +39,18 @@ class NoUninitializedPropertiesWalker extends Lint.RuleWalker {
 
     private _initializedProperties: string[][] = [];
 
-    visitClassDeclaration(node: ts.ClassDeclaration) {
+    visitClassLikeDeclaration(
+        node: ts.ClassDeclaration,
+        superMethod: Lint.RuleWalker['visitClassDeclaration'],
+    ): void;
+    visitClassLikeDeclaration(
+        node: ts.ClassExpression,
+        superMethod: Lint.RuleWalker['visitClassExpression'],
+    ): void;
+    visitClassLikeDeclaration(
+        node: ts.ClassDeclaration | ts.ClassExpression,
+        superMethod: Lint.RuleWalker['visitClassDeclaration'] | Lint.RuleWalker['visitClassExpression'],
+    ): void {
         if (!super.hasOption(Options.PROPERTIES)) {
             return;
         }
@@ -65,8 +76,16 @@ class NoUninitializedPropertiesWalker extends Lint.RuleWalker {
             }
         }
         this._initializedProperties.push(_currentClassInitializedProperties);
-        super.visitClassDeclaration(node);
+        superMethod.call(this, node);
         this._initializedProperties.pop();
+    }
+
+    visitClassDeclaration(node: ts.ClassDeclaration) {
+        this.visitClassLikeDeclaration(node, super.visitClassDeclaration);
+    }
+
+    visitClassExpression(node: ts.ClassExpression) {
+        this.visitClassLikeDeclaration(node, super.visitClassExpression);
     }
 
     visitPropertyDeclaration(node: ts.PropertyDeclaration) {

--- a/src/noUninitializedRule.ts
+++ b/src/noUninitializedRule.ts
@@ -39,17 +39,17 @@ class NoUninitializedPropertiesWalker extends Lint.RuleWalker {
 
     private _initializedProperties: string[][] = [];
 
-    visitClassLikeDeclaration(
+    private visitClassLikeDeclaration(
         node: ts.ClassDeclaration,
-        superMethod: Lint.RuleWalker['visitClassDeclaration'],
+        superMethodName: 'visitClassDeclaration',
     ): void;
-    visitClassLikeDeclaration(
+    private visitClassLikeDeclaration(
         node: ts.ClassExpression,
-        superMethod: Lint.RuleWalker['visitClassExpression'],
+        superMethodName: 'visitClassExpression',
     ): void;
-    visitClassLikeDeclaration(
+    private visitClassLikeDeclaration(
         node: ts.ClassDeclaration | ts.ClassExpression,
-        superMethod: Lint.RuleWalker['visitClassDeclaration'] | Lint.RuleWalker['visitClassExpression'],
+        superMethodName: 'visitClassDeclaration' | 'visitClassExpression',
     ): void {
         if (!super.hasOption(Options.PROPERTIES)) {
             return;
@@ -76,16 +76,20 @@ class NoUninitializedPropertiesWalker extends Lint.RuleWalker {
             }
         }
         this._initializedProperties.push(_currentClassInitializedProperties);
-        superMethod.call(this, node);
+        // Casting is necessary because the compiler believes there may be a mismatch
+        // between the super method's signature and the type of 'node'.
+        // Casting is safe because the overloaded signatures guarantee that this method
+        // cannot be called (within typescript code) with a mismatch.
+        (super[superMethodName] as (node: ts.ClassLikeDeclaration) => void)(node);
         this._initializedProperties.pop();
     }
 
     visitClassDeclaration(node: ts.ClassDeclaration) {
-        this.visitClassLikeDeclaration(node, super.visitClassDeclaration);
+        this.visitClassLikeDeclaration(node, 'visitClassDeclaration');
     }
 
     visitClassExpression(node: ts.ClassExpression) {
-        this.visitClassLikeDeclaration(node, super.visitClassExpression);
+        this.visitClassLikeDeclaration(node, 'visitClassExpression');
     }
 
     visitPropertyDeclaration(node: ts.PropertyDeclaration) {

--- a/test/noUninitialized.propertyInitTestCases.ts
+++ b/test/noUninitialized.propertyInitTestCases.ts
@@ -7,6 +7,13 @@ export const testCases = [
         }`,
     },
     {
+        shouldWarn: true,
+        source:
+        `const X1 = class {
+            prop1: string;
+        };`,
+    },
+    {
         shouldWarn: false,
         source:
         `class X1 {
@@ -16,9 +23,23 @@ export const testCases = [
     {
         shouldWarn: false,
         source:
+        `const X1 = class {
+            prop1: string = '';
+        };`,
+    },
+    {
+        shouldWarn: false,
+        source:
         `class X1 {
             prop1?: string;
         }`,
+    },
+    {
+        shouldWarn: false,
+        source:
+        `const X1 = class {
+            prop1?: string;
+        };`,
     },
     {
         shouldWarn: true,
@@ -27,6 +48,14 @@ export const testCases = [
             prop1: string;
             constructor() { }
         }`,
+    },
+    {
+        shouldWarn: true,
+        source:
+        `const X1 = class {
+            prop1: string;
+            constructor() { }
+        };`,
     },
     {
         shouldWarn: false,
@@ -41,9 +70,26 @@ export const testCases = [
     {
         shouldWarn: false,
         source:
+        `const X1 = class {
+            prop1: string;
+            constructor() {
+                this.prop1 = '';
+            }
+        };`,
+    },
+    {
+        shouldWarn: false,
+        source:
         `class X1 {
             prop1: string | undefined;
         }`,
+    },
+    {
+        shouldWarn: false,
+        source:
+        `const X1 = class {
+            prop1: string | undefined;
+        };`,
     },
     {
         shouldWarn: true,
@@ -55,9 +101,23 @@ export const testCases = [
     {
         shouldWarn: true,
         source:
+        `const X1 = class {
+            prop1: string | null;
+        };`,
+    },
+    {
+        shouldWarn: true,
+        source:
         `abstract class X1 {
             prop1: string;
         }`,
+    },
+    {
+        shouldWarn: true,
+        source:
+        `const X1 = abstract class {
+            prop1: string;
+        };`,
     },
     {
         shouldWarn: false,
@@ -68,5 +128,15 @@ export const testCases = [
                 this.prop1 = '';
             }
         }`,
+    },
+    {
+        shouldWarn: false,
+        source:
+        `const X1 = abstract class {
+            prop1: string;
+            constructor() {
+                this.prop1 = '';
+            }
+        };`,
     },
 ];


### PR DESCRIPTION
Fixes https://github.com/alhugone/tslint-strict-null-checks/issues/4.

Abstracted the implementation of visitClassDeclaration into a new visitClassLikeDeclaration method that is now reused by both visitClassDeclaration and the new visitClassExpression implementation.

Duplicated all "property" unit tests as class expressions. Confirmed that new unit tests fail without changes, pass with changes.