### PR TITLE
Ignore code in module declarations (a.k.a., ambient contexts)

### DIFF
--- a/src/noUninitializedRule.ts
+++ b/src/noUninitializedRule.ts
@@ -18,6 +18,13 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class NoUninitializedVariableWalker extends Lint.RuleWalker {
+    protected visitModuleDeclaration(node: ts.ModuleDeclaration): void {
+        // By doing nothing and not calling the super implementation, this prevents anything within a
+        // module declaration from being considered by this rule.
+        // Module declarations are "ambient contexts" where initializations are not allowed, so it is
+        // nonsense to check for uninitialized variables within such a context.
+        return;
+    }
 
     protected visitVariableDeclaration(node: ts.VariableDeclaration) {
         super.visitVariableDeclaration(node);
@@ -38,6 +45,14 @@ class NoUninitializedVariableWalker extends Lint.RuleWalker {
 class NoUninitializedPropertiesWalker extends Lint.RuleWalker {
 
     private _initializedProperties: string[][] = [];
+
+    protected visitModuleDeclaration(node: ts.ModuleDeclaration): void {
+        // By doing nothing and not calling the super implementation, this prevents anything within a
+        // module declaration from being considered by this rule.
+        // Module declarations are "ambient contexts" where initializations are not allowed, so it is
+        // nonsense to check for uninitialized properties within such a context.
+        return;
+    }
 
     visitClassDeclaration(node: ts.ClassDeclaration) {
         if (!super.hasOption(Options.PROPERTIES)) {

--- a/test/noUninitialized.propertyInitTestCases.ts
+++ b/test/noUninitialized.propertyInitTestCases.ts
@@ -69,4 +69,26 @@ export const testCases = [
             }
         }`,
     },
+    {
+        shouldWarn: false,
+        source: `
+            declare module "foo" {
+                class X1 {
+                    public prop1: string;
+                }
+                export default X1;
+            }
+        `,
+    },
+    {
+        shouldWarn: false,
+        source: `
+            declare module "foo" {
+                abstract class X1 {
+                    public prop1: string;
+                }
+                export default X1;
+            }
+        `,
+    },
 ];

--- a/test/noUninitialized.variableInitTestCases.ts
+++ b/test/noUninitialized.variableInitTestCases.ts
@@ -32,4 +32,13 @@ export const testCases = [
     { source: `let a=1, b=2, c `, shouldWarn: true },
     { source: `let a=1, b=2, c =3`, shouldWarn: false },
     { source: `let a:any`, shouldWarn: true },
+    {
+        shouldWarn: false,
+        source: `
+            declare module "foo" {
+                const value: number;
+                export default value;
+            }
+        `,
+    },
 ];


### PR DESCRIPTION
Fixes this issue: https://github.com/alhugone/tslint-strict-null-checks/issues/6